### PR TITLE
Issue#2 escape quotation marks

### DIFF
--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -23,7 +23,7 @@ class HtmlTestHook < Mumukit::Hook
   end
 
   def render_html(actual)
-    "<br><div class=\"mu-browser\"><iframe srcdoc=\"#{actual.gsub('"', '\"')}\"></iframe></div>"
+    "<br><div class=\"mu-browser\"><iframe srcdoc=\"#{actual.gsub('"', '&quot;')}\"></iframe></div>"
   end
 
 end

--- a/mumuki-html-runner.gemspec
+++ b/mumuki-html-runner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'mumukit', '~> 2.7'
+  spec.add_dependency 'mumukit', '~> 2.18'
 
   spec.add_development_dependency 'mumukit-content-type', '~> 0.4.0'
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -44,7 +44,7 @@ describe 'integration test' do
                                 test_results: [],
                                 status: :passed,
                                 feedback: '',
-                                result: "<br><div class=\"mu-browser\"><iframe srcdoc=\"<meta charset=\\\"UTF-8\\\">\"></iframe></div>",
+                                result: "<br><div class=\"mu-browser\"><iframe srcdoc=\"<meta charset=&quot;UTF-8&quot;>\"></iframe></div>",
                                 expectation_results: [] }
   end
 


### PR DESCRIPTION
Proper way to escape quotes is `&quot;` according to:
https://stackoverflow.com/questions/4015345/how-to-properly-escape-quotes-inside-html-attributes

Fixes #2.