### PR TITLE
Add support for return html in empty spec

### DIFF
--- a/lib/html_runner.rb
+++ b/lib/html_runner.rb
@@ -10,6 +10,7 @@ Mumukit.runner_name = 'html'
 Mumukit.configure do |config|
   config.content_type = 'html'
   config.process_expectations_on_empty_content = true
+  config.run_test_hook_on_empty_test = true
 end
 
 require_relative './metadata_hook'

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -14,7 +14,7 @@ class HtmlTestHook < Mumukit::Hook
   def run!(request)
     expected = request[:test]
     actual = request[:extra] || request[:content]
-    if contents_match?(expected, actual) || expected.blank?
+    if expected.blank? || contents_match?(expected, actual)
       [render_html(actual), :passed]
     else
       [render_fail_html(actual, expected), :failed]

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -14,8 +14,7 @@ class HtmlTestHook < Mumukit::Hook
   def run!(request)
     expected = request[:test]
     actual = request[:extra] || request[:content]
-
-    if contents_match?(expected, actual)
+    if contents_match?(expected, actual) || expected.blank?
       [render_html(actual), :passed]
     else
       [render_fail_html(actual, expected), :failed]

--- a/mumuki-html-runner.gemspec
+++ b/mumuki-html-runner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'mumukit', '~> 2.22'
+  spec.add_dependency 'mumukit', '~> 2.23'
   spec.add_dependency 'hexp', '~> 0.4'
   spec.add_dependency 'css_parser', '~> 1.6'
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -315,8 +315,9 @@ html
 html
                                 expectation_results: [] }
   end
+
   context 'when content is empty expectations run' do
-    let(:test) { {content: 'p {color: blue;}', extra: '<html><head><style>/*...content...*/</style><head></html>',
+    let(:test) { {content: 'p {color: blue;}', extra: '<html><head><style>/*...content...*/</style></head></html>',
                   expectations: [
                     {binding: 'css:p', inspection: 'DeclaresStyle:color:blue'},
                     {binding: 'css:p', inspection: 'DeclaresStyle:color'}],
@@ -325,10 +326,54 @@ html
     it { expect(response).to eq response_type: :unstructured,
                                 test_results: [],
                                 status: :passed,
-                                result: '',
+                                result: <<html,
+<div class="mu-browser" data-srcdoc="#{'<html><head><style>p {color: blue;}</style></head></html>'.escape_html}">
+</div>
+html
                                 feedback: '',
                                 expectation_results: [
                                   {binding: 'css:p', inspection: 'DeclaresStyle:color:blue', result: :passed},
                                   {binding: 'css:p', inspection: 'DeclaresStyle:color', result: :passed}] }
+  end
+
+  context 'when using expectations only' do
+    let(:test) { {
+      content: '<html><head><style>p {color: blue;}</style></head></html>',
+      test: '',
+      expectations: [
+        {binding: 'css:p', inspection: 'DeclaresStyle:color'},
+        {binding: 'css:p', inspection: 'DeclaresStyle:color:blue'}]} }
+
+    it { expect(response).to eq response_type: :unstructured,
+                                                test_results: [],
+                                                status: :passed,
+                                                feedback: '',
+                                                result: <<html,
+<div class="mu-browser" data-srcdoc="#{'<html><head><style>p {color: blue;}</style></head></html>'.escape_html}">
+</div>
+html
+                                                expectation_results: [
+                                                  {binding: 'css:p', inspection: 'DeclaresStyle:color', result: :passed},
+                                                  {binding: 'css:p', inspection: 'DeclaresStyle:color:blue', result: :passed}] }
+  end
+  context 'when using wrong expectations only' do
+    let(:test) { {
+      content: '<html><head><style>p {color: blue;}</style></head></html>',
+      test: '',
+      expectations: [
+        {binding: 'css:p', inspection: 'DeclaresStyle:color'},
+        {binding: 'css:p', inspection: 'DeclaresStyle:color:red'}]} }
+
+    it { expect(response).to eq response_type: :unstructured,
+                                                test_results: [],
+                                                status: :passed_with_warnings,
+                                                feedback: '',
+                                                result: <<html,
+<div class="mu-browser" data-srcdoc="#{'<html><head><style>p {color: blue;}</style></head></html>'.escape_html}">
+</div>
+html
+                                                expectation_results: [
+                                                  {binding: 'css:p', inspection: 'DeclaresStyle:color', result: :passed},
+                                                  {binding: 'css:p', inspection: 'DeclaresStyle:color:red', result: :failed}] }
   end
 end


### PR DESCRIPTION
![bitmoji](https://render.bitstrips.com/v2/cpanel/c0871c38-0c27-4ae4-9196-389fa986867a-ffe5b08d-c271-4b7d-b267-708d3e0b004c-v1.png?transparent=1&palette=1&width=246)