### PR TITLE
Multifile

### DIFF
--- a/lib/expectations_hook.rb
+++ b/lib/expectations_hook.rb
@@ -4,7 +4,7 @@ class HtmlExpectationsHook < Mumukit::Hook
   end
 
   def run!(request)
-    document = Nokogiri::HTML(request.content)
+    document = Nokogiri::HTML(compile_content(request))
     request.expectations.map do |raw|
       evaluate_expectation raw, document
     end
@@ -26,5 +26,9 @@ class HtmlExpectationsHook < Mumukit::Hook
 
   def negate(expectation, matches)
     expectation.inspection.negated? ? matches.blank? : matches.present?
+  end
+
+  def compile_content(request)
+    request.content.presence || request.extra
   end
 end

--- a/lib/expectations_hook.rb
+++ b/lib/expectations_hook.rb
@@ -4,7 +4,7 @@ class HtmlExpectationsHook < Mumukit::Hook
   end
 
   def run!(request)
-    document = Nokogiri::HTML(compile_content(request))
+    document = Nokogiri::HTML(request.content)
     request.expectations.map do |raw|
       evaluate_expectation raw, document
     end
@@ -22,10 +22,6 @@ class HtmlExpectationsHook < Mumukit::Hook
   def checker_for(expectation)
     lang = expectation.binding.starts_with?('css:')? 'CSS' : 'HTML'
     "Checker::#{lang}".constantize
-  end
-
-  def compile_content(request)
-    request.content.presence || request.extra
   end
 
   def negate(expectation, matches)

--- a/lib/extensions/string.rb
+++ b/lib/extensions/string.rb
@@ -1,0 +1,9 @@
+class String
+  def escape_html
+    ERB::Util.html_escape self
+  end
+
+  def get_extension
+    self.split('.').last
+  end
+end

--- a/lib/html_runner.rb
+++ b/lib/html_runner.rb
@@ -3,7 +3,6 @@ require 'yaml'
 require 'nokogiri'
 require 'hexp'
 require 'css_parser'
-require 'mumukit/hook'
 
 I18n.load_translations_path File.join(__dir__, 'locales', '*.yml')
 

--- a/lib/html_runner.rb
+++ b/lib/html_runner.rb
@@ -3,6 +3,7 @@ require 'yaml'
 require 'nokogiri'
 require 'hexp'
 require 'css_parser'
+require 'mumukit/hook'
 
 I18n.load_translations_path File.join(__dir__, 'locales', '*.yml')
 
@@ -13,7 +14,9 @@ Mumukit.configure do |config|
   config.run_test_hook_on_empty_test = true
 end
 
+require_relative './extensions/string'
 require_relative './metadata_hook'
+require_relative './precompile_hook'
 require_relative './test_hook'
 require_relative './checker'
 require_relative './expectations_hook'

--- a/lib/html_runner.rb
+++ b/lib/html_runner.rb
@@ -12,6 +12,7 @@ Mumukit.configure do |config|
   config.content_type = 'html'
   config.process_expectations_on_empty_content = true
   config.run_test_hook_on_empty_test = true
+  config.multifile = true
 end
 
 require_relative './extensions/string'

--- a/lib/precompile_hook.rb
+++ b/lib/precompile_hook.rb
@@ -12,7 +12,10 @@ class HtmlPrecompileHook < Mumukit::Templates::MultiFilePrecompileHook
     document = Nokogiri::HTML(main_content)
     merge_script_tags! document, files_by_extension
     merge_style_tags! document, files_by_extension
+
     document.to_html
+      .gsub(/<!DOCTYPE[^>]+>/, '')
+      .gsub(/<meta[^>]+>/, '')
   end
 
   def files_of(request)

--- a/lib/precompile_hook.rb
+++ b/lib/precompile_hook.rb
@@ -1,36 +1,4 @@
-# // TODO: Move to mumukit
-class MultiFilePrecompileHook < Mumukit::Hook
-  def compile(request)
-    files = files_of request
-    content = files.empty? ? single_file_content(request) : multi_file_content(files)
-
-    struct request.to_h.merge content: content
-  end
-
-  def main_file
-    raise NotImplementedError
-  end
-
-  def consolidate(main_content, files)
-    raise NotImplementedError
-  end
-
-  def single_file_content(request)
-    request.content
-  end
-
-  def multi_file_content(files)
-    return files.values.first if files.count == 1
-
-    consolidate(files[main_file] || '', files)
-  end
-
-  def files_of(request)
-    request.to_stringified_h.select { |key, _| key.include? '.' }
-  end
-end
-
-class HtmlPrecompileHook < MultiFilePrecompileHook
+class HtmlPrecompileHook < Mumukit::Templates::MultiFilePrecompileHook
   VALID_EXTENSIONS = ['.html', '.js', '.css']
 
   def main_file
@@ -73,7 +41,7 @@ class HtmlPrecompileHook < MultiFilePrecompileHook
       return if rel != 'stylesheet'
 
       href = tag.get_attribute 'href'
-      file = files_by_extension.dig('css', src)
+      file = files_by_extension.dig('css', href)
       tag.replace("<style>#{file}</style>") if file.present?
     }
   end

--- a/lib/precompile_hook.rb
+++ b/lib/precompile_hook.rb
@@ -1,0 +1,80 @@
+# // TODO: Move to mumukit
+class MultiFilePrecompileHook < Mumukit::Hook
+  def compile(request)
+    files = files_of request
+    content = files.empty? ? single_file_content(request) : multi_file_content(files)
+
+    struct request.to_h.merge content: content
+  end
+
+  def main_file
+    raise NotImplementedError
+  end
+
+  def consolidate(main_content, files)
+    raise NotImplementedError
+  end
+
+  def single_file_content(request)
+    request.content
+  end
+
+  def multi_file_content(files)
+    return files.values.first if files.count == 1
+
+    consolidate(files[main_file] || '', files)
+  end
+
+  def files_of(request)
+    request.to_stringified_h.select { |key, _| key.include? '.' }
+  end
+end
+
+class HtmlPrecompileHook < MultiFilePrecompileHook
+  VALID_EXTENSIONS = ['.html', '.js', '.css']
+
+  def main_file
+    'index.html'
+  end
+
+  def consolidate(main_content, files)
+    files_by_extension = files.group_by { |file_name, _| file_name.get_extension }
+    files_by_extension.each { |extension, values| files_by_extension[extension] = values.to_h }
+
+    document = Nokogiri::HTML(main_content)
+    merge_script_tags! document, files_by_extension
+    merge_style_tags! document, files_by_extension
+    document.to_html
+  end
+
+  def single_file_content(request)
+    request.content.presence || request.extra
+  end
+
+  def files_of(request)
+    super(request).select { |file_name, _|
+      VALID_EXTENSIONS.any? { |extension| file_name.end_with? extension }
+    }
+  end
+
+  private
+
+  def merge_script_tags!(document, files_by_extension)
+    document.xpath("//script").each { |tag|
+      src = tag.get_attribute 'src'
+      file = files_by_extension.dig('js', src)
+      tag.replace("<script>#{file}</script>") if file.present?
+    }
+  end
+
+  def merge_style_tags!(document, files_by_extension)
+    document.xpath("//link").each { |tag|
+      rel = tag.get_attribute 'rel'
+      return if rel != 'stylesheet'
+
+      href = tag.get_attribute 'href'
+      file = files_by_extension.dig('css', src)
+      tag.replace("<style>#{file}</style>") if file.present?
+    }
+  end
+end

--- a/lib/precompile_hook.rb
+++ b/lib/precompile_hook.rb
@@ -15,10 +15,6 @@ class HtmlPrecompileHook < Mumukit::Templates::MultiFilePrecompileHook
     document.to_html
   end
 
-  def single_file_content(request)
-    request.content.presence || request.extra
-  end
-
   def files_of(request)
     super(request).select { |file_name, _|
       VALID_EXTENSIONS.any? { |extension| file_name.end_with? extension }

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -22,7 +22,7 @@ class HtmlTestHook < Mumukit::Hook
   end
 
   def hexp_without_blanks(content)
-    hexp ["\r", "\n", "\t"]
+    hexp %W(\r \n \t)
            .reduce(content.strip) { |c, it| c.gsub(it, ' ') }
            .squeeze(' ')
   end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -5,13 +5,15 @@ class HtmlTestHook < Mumukit::Hook
 
   def run!(request)
     expected = request.test
-    actual = request.content
+    actual = compile_content request
     if expected.blank? || contents_match?(expected, actual)
       [render_html(actual), :passed]
     else
       [render_fail_html(actual, expected), :failed]
     end
   end
+
+  private
 
   def contents_match?(expected, actual)
     hexp_without_blanks(expected) == hexp_without_blanks(actual)
@@ -63,4 +65,7 @@ html
 html
   end
 
+  def compile_content(request)
+    request.extra.presence || request.content
+  end
 end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -1,19 +1,11 @@
-require 'mumukit/hook'
-
-class String
-  def escape_html
-    ERB::Util.html_escape self
-  end
-end
-
 class HtmlTestHook < Mumukit::Hook
   def compile(request)
     request
   end
 
   def run!(request)
-    expected = request[:test]
-    actual = request[:extra].presence || request[:content]
+    expected = request.test
+    actual = request.content
     if expected.blank? || contents_match?(expected, actual)
       [render_html(actual), :passed]
     else

--- a/mumuki-html-runner.gemspec
+++ b/mumuki-html-runner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'mumukit', '~> 2.23'
+  spec.add_dependency 'mumukit', '~> 2.24'
   spec.add_dependency 'hexp', '~> 0.4'
   spec.add_dependency 'css_parser', '~> 1.6'
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -36,7 +36,7 @@ describe 'integration test' do
                                                 expectation_results: [] }
   end
 
-    context 'when extra code is equal to expected' do
+  context 'when extra code is equal to expected' do
     let(:test) { {content: '<body></body>', extra: '<html>/*...content...*/</html>',
                   test: '<html><body></body></html>'} }
 
@@ -47,6 +47,26 @@ describe 'integration test' do
                                                 expectation_results: [] }
   end
 
+  context 'when using multiple files' do
+    let(:test) { {"index.html": '<html><head><script src="foo.js"></script> <link rel="stylesheet" href="bar.css" /></head><body>Baz</body></html>',
+                  "foo.js": 'alert("foo");',
+                  "bar.css": '.red { color: red; }',
+                  test: <<html,
+<html>
+  <head>
+    <script>alert("foo");</script> <style>.red { color: red; }</style>
+  </head>
+  <body>Baz</body>
+</html>
+html
+} }
+
+    it { expect(response.except(:result)).to eq response_type: :unstructured,
+                                                test_results: [],
+                                                status: :passed,
+                                                feedback: '',
+                                                expectation_results: [] }
+  end
 
   context 'when using expectations only' do
     let(:test) { {

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -48,9 +48,12 @@ describe 'integration test' do
   end
 
   context 'when using multiple files' do
-    let(:test) { {"index.html": '<html><head><script src="foo.js"></script> <link rel="stylesheet" href="bar.css" /></head><body>Baz</body></html>',
-                  "foo.js": 'alert("foo");',
-                  "bar.css": '.red { color: red; }',
+    let(:test) { {
+                  content: <<content,
+/*<index.html#*/<html><head><script src="foo.js"></script> <link rel="stylesheet" href="bar.css" /></head><body>Baz</body></html>/*#index.html>*/
+/*<foo.js#*/alert("foo");/*#foo.js>*/
+/*<bar.css#*/.red { color: red; }/*#bar.css>*/
+content
                   test: <<html,
 <html>
   <head>


### PR DESCRIPTION
Depende de https://github.com/mumuki/mumukit/pull/86 (por eso no pasan los tests)

Demo: https://youtu.be/DMjJlCCFeT8

Lo que pensé hasta ahora fue que el alumno puede/deba definir un archivo principal (en este caso index.html) en el que puede incluir otros archivos con los tags de HTML comunes.

Los runners ahora reciben en la request todos los archivos y los pueden pedir con este [files_of](https://github.com/mumuki/mumukit/blob/c81e3389376066b901e166c9b5db2dddc8a84d99/lib/mumukit/templates/with_multiple_files.rb#L2).

El runner en el precompile arma el html final para poder compararlo contra el test. En otros runners más complejos se podrían hacer otras cosas con los archivos en vez de eso (como por ejemplo mandar a compilar varios .java a la vez, y soportar expectations sobre los archivos)