### PR TITLE
Ajax support

### DIFF
--- a/lib/html_runner.rb
+++ b/lib/html_runner.rb
@@ -8,7 +8,7 @@ I18n.load_translations_path File.join(__dir__, 'locales', '*.yml')
 
 Mumukit.runner_name = 'html'
 Mumukit.configure do |config|
-  config.docker_image = 'mumuki/mumuki-html-worker:1.2'
+  config.docker_image = 'mumuki/mumuki-html-worker:1.3'
   config.content_type = 'html'
   config.process_expectations_on_empty_content = true
   config.run_test_hook_on_empty_test = true

--- a/lib/html_runner.rb
+++ b/lib/html_runner.rb
@@ -8,7 +8,7 @@ I18n.load_translations_path File.join(__dir__, 'locales', '*.yml')
 
 Mumukit.runner_name = 'html'
 Mumukit.configure do |config|
-  config.docker_image = 'mumuki/mumuki-html-worker:1.1'
+  config.docker_image = 'mumuki/mumuki-html-worker:1.2'
   config.content_type = 'html'
   config.process_expectations_on_empty_content = true
   config.run_test_hook_on_empty_test = true

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:6.14
 MAINTAINER Rodrigo Alfonso
 
-RUN npm install -g run-dom-tests@1.1.1
+RUN npm install -g run-dom-tests@1.2.0

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:6.14
 MAINTAINER Rodrigo Alfonso
 
-RUN npm install -g run-dom-tests@1.2.0
+RUN npm install -g run-dom-tests@1.2.1


### PR DESCRIPTION
# Merge https://github.com/mumuki/mumuki-html-runner/pull/36 first!

Diffs: https://github.com/mumuki/mumuki-html-runner/compare/dom-assertions...ajax-support

I added support for testing AJAX calls through [nock](https://github.com/nock/nock) in https://github.com/rodri042/run-dom-tests/commit/914d193cde4930be6c31b9fb898ca9133baf5b86