### PR TITLE
Trim whitespaces inside HTML nodes unless `maintain_inner_whitespaces` option is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
 > Sinatra server for validating HTML exercises within [Mumuki](http://github.com/mumuki)
 
 ## Prerequisites
-  Install rbenv:
+  Install `rbenv`:
 
 >You can install rbenv following the instructions of this [Link](http://uqbar-wiki.org/index.php?title=Gu%C3%ADa_de_Instalaci%C3%B3n_de_Ruby)
+
+  Install `docker`
+
+>You can install docker following the instructions of this [Link](https://docs.docker.com/get-started/)
 
 ## Setup
  Open  the Terminal Console, located in this project's
@@ -49,7 +53,7 @@ Also you can all the tests running the following command:
 
     bundle exec rake
 
-If you want to run the test using rubymine just look for the "spec"     folder inside mumuki-html-runner project, right click on the      prevously mention folder and click on "Run all Specs..." option.
+If you want to run the test using rubymine just look for the "spec"     folder inside mumuki-html-runner project, right click on the      previously mentioned folder and click on "Run all Specs..." option.
 
 If you have done the steps correctly both ways of running test should do it successfully.
 

--- a/lib/test_dom_hook.rb
+++ b/lib/test_dom_hook.rb
@@ -1,3 +1,9 @@
+class Hexp::Node
+  def flat_map_children(&blk)
+    H[tag, attributes, children.flat_map(&blk)]
+  end
+end
+
 class HtmlTestDomHook < Mumukit::Hook
   def compile(request)
     request
@@ -45,15 +51,13 @@ class HtmlTestDomHook < Mumukit::Hook
     unless options['keep_outer_whitespaces']
       exp = remove_whitespaces_recursively exp
     end
-
     exp
   end
 
   def remove_whitespaces_recursively(hexp)
-    hexp.map_children do |node|
+    hexp.flat_map_children do |node|
       next remove_whitespaces_recursively(node) unless node.text?
-
-      node.strip.empty? ? node : node.strip
+      [node.strip.presence].compact
     end
   end
 
@@ -63,8 +67,8 @@ class HtmlTestDomHook < Mumukit::Hook
            .squeeze(' ')
   end
 
-  def hexp(squeezed_content)
-    Hexp.parse("<html>#{squeezed_content}</html>")
+  def hexp(content)
+    Hexp.parse("<html>#{content}</html>")
   end
 
   def render_html(actual)

--- a/lib/test_dom_hook.rb
+++ b/lib/test_dom_hook.rb
@@ -34,8 +34,6 @@ class HtmlTestDomHook < Mumukit::Hook
   end
 
   def transform_content(content, options)
-    return remove_inner_whitespaces(content) unless options.present?
-
     if options['keep_inner_whitespaces']
       exp = hexp content
     else

--- a/lib/test_dom_hook.rb
+++ b/lib/test_dom_hook.rb
@@ -49,14 +49,14 @@ class HtmlTestDomHook < Mumukit::Hook
     end
 
     unless options['maintain_inner_whitespaces']
-      return remove_inner_whitespaces (exp.to_html)
+      exp = remove_inner_whitespaces(exp.to_html)
     end
 
     exp.to_html
   end
 
   def remove_inner_whitespaces(content)
-    remove_whitespaces_recursively(hexp_without_blanks(content)).to_html
+    remove_whitespaces_recursively(hexp_without_blanks(content))
   end
 
   def remove_whitespaces_recursively(hexp)

--- a/lib/test_dom_hook.rb
+++ b/lib/test_dom_hook.rb
@@ -36,7 +36,11 @@ class HtmlTestDomHook < Mumukit::Hook
   def transform_content(content, options)
     return remove_inner_whitespaces(content) unless options.present?
 
-    exp = hexp_without_blanks content
+    if options['keep_inner_whitespaces']
+      exp = hexp content
+    else
+      exp = hexp_without_blanks content
+    end
 
     if options['output_ignore_scripts']
       exp = exp.replace('script') { [] }

--- a/lib/test_dom_hook.rb
+++ b/lib/test_dom_hook.rb
@@ -28,12 +28,6 @@ class HtmlTestDomHook < Mumukit::Hook
   end
 
   def comparable_hexp(content, options)
-    html = transform_content content, options
-
-    hexp_without_blanks html
-  end
-
-  def transform_content(content, options)
     if options['keep_inner_whitespaces']
       exp = hexp content
     else
@@ -48,15 +42,11 @@ class HtmlTestDomHook < Mumukit::Hook
       exp = exp.replace('style') { [] }
     end
 
-    unless options['maintain_inner_whitespaces']
-      exp = remove_inner_whitespaces(exp.to_html)
+    unless options['keep_outer_whitespaces']
+      exp = remove_whitespaces_recursively exp
     end
 
-    exp.to_html
-  end
-
-  def remove_inner_whitespaces(content)
-    remove_whitespaces_recursively(hexp_without_blanks(content))
+    exp
   end
 
   def remove_whitespaces_recursively(hexp)

--- a/lib/test_dom_hook.rb
+++ b/lib/test_dom_hook.rb
@@ -54,9 +54,7 @@ class HtmlTestDomHook < Mumukit::Hook
   end
 
   def remove_inner_whitespaces(content)
-    content = hexp_without_blanks(content)
-    content = remove_whitespaces_recursively content
-    content.to_html
+    remove_whitespaces_recursively(hexp_without_blanks(content)).to_html
   end
 
   def remove_whitespaces_recursively(hexp)

--- a/lib/test_dom_hook.rb
+++ b/lib/test_dom_hook.rb
@@ -47,7 +47,7 @@ class HtmlTestDomHook < Mumukit::Hook
     end
 
     unless options['maintain_inner_whitespaces']
-      exp = remove_inner_whitespaces exp
+      return remove_inner_whitespaces (exp.to_html)
     end
 
     exp.to_html
@@ -55,15 +55,13 @@ class HtmlTestDomHook < Mumukit::Hook
 
   def remove_inner_whitespaces(content)
     content = hexp_without_blanks(content)
-    content = remove_whitespaces_in_children_recursively content
+    content = remove_whitespaces_recursively content
     content.to_html
   end
 
-  def remove_whitespaces_in_children_recursively(hexp)
+  def remove_whitespaces_recursively(hexp)
     hexp.map_children do |node|
-      unless node.text?
-        next remove_whitespaces_in_children_recursively(node)
-      end
+      next remove_whitespaces_recursively(node) unless node.text?
 
       node.strip.empty? ? node : node.strip
     end

--- a/spec/full_integration_spec.rb
+++ b/spec/full_integration_spec.rb
@@ -360,7 +360,7 @@ maintain_inner_whitespaces: true
 /*#options>*/
 TEST
     }
-    context 'when whitespaces are maintained' do
+    context 'when whitespaces are maintained and respected' do
       let(:request) { {
         content: <<CONTENT,
 /*<index.html#*/
@@ -382,6 +382,32 @@ CONTENT
       it { expect(response.except(:result)).to eq response_type: :unstructured,
                                                   test_results: [],
                                                   status: :passed,
+                                                  feedback: '',
+                                                  expectation_results: [] }
+    end
+
+    context 'when whitespaces are maintained and ignored' do
+      let(:request) { {
+        content: <<CONTENT,
+/*<index.html#*/
+<html>
+  <head>
+    <title>page title</title>
+  </head>
+  <body>
+    <strong id="message">hello</strong>
+  </body>
+</html>
+/*#index.html>*/
+
+CONTENT
+        test: test,
+        expectations: []
+      } }
+
+      it { expect(response.except(:result)).to eq response_type: :unstructured,
+                                                  test_results: [],
+                                                  status: :failed,
                                                   feedback: '',
                                                   expectation_results: [] }
     end

--- a/spec/full_integration_spec.rb
+++ b/spec/full_integration_spec.rb
@@ -229,7 +229,7 @@ CONTENT
 /*<tests#*/
 it("when the user clicks the button, it shows an alert message", function() {
 	should.not.exist(_last_alert_message_);
-  
+
   const button = document.querySelector("button");
   _dispatch_('click', button);
 
@@ -342,7 +342,7 @@ CONTENT
     end
   end
 
-  context 'when testing DOM options' do
+  context 'when using keep_inner_whitespaces' do
     let(:test) { <<TEST
 /*<output#*/
 <html>
@@ -350,17 +350,17 @@ CONTENT
     <title>page title</title>
   </head>
   <body>
-    <strong id="message"> hello </strong>
+    <strong id="message"> hello world </strong>
   </body>
 </html>
 /*#output>*/
 
 /*<options#*/
-maintain_inner_whitespaces: true
+keep_inner_whitespaces: true
 /*#options>*/
 TEST
     }
-    context 'when whitespaces are maintained and respected' do
+    context 'when inner whitespaces are kept and respected' do
       let(:request) { {
         content: <<CONTENT,
 /*<index.html#*/
@@ -369,7 +369,7 @@ TEST
     <title>page title</title>
   </head>
   <body>
-    <strong id="message"> hello </strong>
+    <strong id="message">hello world</strong>
   </body>
 </html>
 /*#index.html>*/
@@ -386,7 +386,7 @@ CONTENT
                                                   expectation_results: [] }
     end
 
-    context 'when whitespaces are maintained and ignored' do
+    context 'when inner whitespaces are kept and ignored' do
       let(:request) { {
         content: <<CONTENT,
 /*<index.html#*/
@@ -395,7 +395,78 @@ CONTENT
     <title>page title</title>
   </head>
   <body>
-    <strong id="message">hello</strong>
+    <strong id="message">hello   world</strong>
+  </body>
+</html>
+/*#index.html>*/
+
+CONTENT
+        test: test,
+        expectations: []
+      } }
+
+      it { expect(response.except(:result)).to eq response_type: :unstructured,
+                                                  test_results: [],
+                                                  status: :failed,
+                                                  feedback: '',
+                                                  expectation_results: [] }
+    end
+  end
+
+  context 'when using keep_outer_whitespaces' do
+    let(:test) { <<TEST
+/*<output#*/
+<html>
+  <head>
+    <title>page title</title>
+  </head>
+  <body>
+    <strong id="message"> hello world </strong>
+  </body>
+</html>
+/*#output>*/
+
+/*<options#*/
+keep_outer_whitespaces: true
+/*#options>*/
+TEST
+    }
+    context 'when outer whitespaces are kept and respected' do
+      let(:request) { {
+        content: <<CONTENT,
+/*<index.html#*/
+<html>
+  <head>
+    <title>page title</title>
+  </head>
+  <body>
+    <strong id="message"> hello  world </strong>
+  </body>
+</html>
+/*#index.html>*/
+
+CONTENT
+        test: test,
+        expectations: []
+      } }
+
+      it { expect(response.except(:result)).to eq response_type: :unstructured,
+                                                  test_results: [],
+                                                  status: :passed,
+                                                  feedback: '',
+                                                  expectation_results: [] }
+    end
+
+    context 'when outer whitespaces are kept and ignored' do
+      let(:request) { {
+        content: <<CONTENT,
+/*<index.html#*/
+<html>
+  <head>
+    <title>page title</title>
+  </head>
+  <body>
+    <strong id="message">hello world</strong>
   </body>
 </html>
 /*#index.html>*/

--- a/spec/full_integration_spec.rb
+++ b/spec/full_integration_spec.rb
@@ -42,7 +42,7 @@ it("calls alert() saying hey", function() {
 output_ignore_scripts: true
 /*#options>*/
 TEST
-  }
+    }
 
     context 'when everything is OK' do
       let(:request) { {
@@ -66,7 +66,7 @@ alert("Hey!!");
 CONTENT
         test: test,
         expectations: [
-          {binding: 'body', inspection: 'DeclaresTag:strong'}
+          { binding: 'body', inspection: 'DeclaresTag:strong' }
         ]
       } }
 
@@ -78,7 +78,7 @@ CONTENT
                                                   status: :passed,
                                                   feedback: '',
                                                   expectation_results: [
-                                                    {binding: 'body', inspection: 'DeclaresTag:strong', result: :passed}
+                                                    { binding: 'body', inspection: 'DeclaresTag:strong', result: :passed }
                                                   ] }
     end
 
@@ -336,6 +336,51 @@ CONTENT
                                                   test_results: [
                                                     { title: 'AJAX: shows the downloaded content when the button is clicked', status: :passed, result: '' }
                                                   ],
+                                                  status: :passed,
+                                                  feedback: '',
+                                                  expectation_results: [] }
+    end
+  end
+
+  context 'when testing DOM options' do
+    let(:test) { <<TEST
+/*<output#*/
+<html>
+  <head>
+    <title>page title</title>
+  </head>
+  <body>
+    <strong id="message"> hello </strong>
+  </body>
+</html>
+/*#output>*/
+
+/*<options#*/
+maintain_inner_whitespaces: true
+/*#options>*/
+TEST
+    }
+    context 'when whitespaces are maintained' do
+      let(:request) { {
+        content: <<CONTENT,
+/*<index.html#*/
+<html>
+  <head>
+    <title>page title</title>
+  </head>
+  <body>
+    <strong id="message"> hello </strong>
+  </body>
+</html>
+/*#index.html>*/
+
+CONTENT
+        test: test,
+        expectations: []
+      } }
+
+      it { expect(response.except(:result)).to eq response_type: :unstructured,
+                                                  test_results: [],
                                                   status: :passed,
                                                   feedback: '',
                                                   expectation_results: [] }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -243,7 +243,7 @@ html
 
     it { expect(response.except(:result)).to eq response_type: :unstructured,
                                                 test_results: [],
-                                                status: :failed,
+                                                status: :passed,
                                                 feedback: '',
                                                 expectation_results: [] }
   end
@@ -270,8 +270,8 @@ html
                                                 expectation_results: [] }
   end
 
-  context 'when code has extra new-lines' do
-    let(:test) { {content: "<html>\n</html>",
+  context 'when code has extra head' do
+    let(:test) { {content: "<html><head></head></html>",
                   test: '<html></html>'} }
 
     it { expect(response).to eq response_type: :unstructured,
@@ -281,7 +281,7 @@ html
                                 result: <<html,
 <br>
 <strong>Actual</strong>
-<div class="mu-browser" data-srcdoc="#{"<html>\n</html>".escape_html}">
+<div class="mu-browser" data-srcdoc="#{"<html><head></head></html>".escape_html}">
 </div>
 
 <br>
@@ -292,6 +292,22 @@ html
 html
                                 expectation_results: [] }
   end
+
+  context 'when code has extra new-lines' do
+    let(:test) { {content: "<html>\n</html>",
+                  test: "<html></html>"} }
+
+    it { expect(response).to eq response_type: :unstructured,
+                                test_results: [],
+                                status: :passed,
+                                feedback: '',
+                                result: <<html,
+<div class="mu-browser" data-srcdoc="#{"<html>\n</html>".escape_html}">
+</div>
+html
+                                expectation_results: [] }
+  end
+
 
   context 'when code has repeated new-lines' do
     let(:test) { {content: "<html>\n\n</html>",

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -47,6 +47,17 @@ describe 'integration test' do
                                                 expectation_results: [] }
   end
 
+  context 'when code is equal to expected, but has inner trailing whitespaces' do
+    let(:test) { {content: '<ul><li> Programación con objetos </li><li> Ruby </li><li> HTML </li></ul>',
+                  test: '<ul><li>Programación con objetos</li><li>Ruby</li><li>HTML</li></ul>'} }
+
+    it { expect(response.except(:result)).to eq response_type: :unstructured,
+                                                test_results: [],
+                                                status: :passed,
+                                                feedback: '',
+                                                expectation_results: [] }
+  end
+
   context 'when using multiple files' do
     let(:test) { {
                   content: <<content,

--- a/spec/test_dom_hook_spec.rb
+++ b/spec/test_dom_hook_spec.rb
@@ -3,14 +3,30 @@ require_relative 'spec_helper'
 describe HtmlTestDomHook do
   subject { HtmlTestDomHook.new }
 
-  def expect_comparable_html_to_eq(original, expected)
-    expect(subject.send(:comparable_hexp, original, {}).to_html).to eq expected
+  def expect_comparable_html_to_eq(original, expected, options = {})
+    expect(subject.send(:comparable_hexp, original, options).to_html).to eq expected
   end
 
   it { expect_comparable_html_to_eq '<div> </div>', '<html><body><div></div></body></html>' }
   it { expect_comparable_html_to_eq '<html></html>', '<html></html>' }
   it { expect_comparable_html_to_eq "<html><body><p> hello world </p></body></html>", '<html><body><p>hello world</p></body></html>' }
+
   it { expect_comparable_html_to_eq "<html><body><p>      hello     world     </p></body></html>", '<html><body><p>hello world</p></body></html>' }
+  it { expect_comparable_html_to_eq "<html><body><p>      hello\t\tworld     </p></body></html>", '<html><body><p>hello world</p></body></html>' }
+
+  it { expect_comparable_html_to_eq "<html><body><p>      hello\t\tworld     </p></body></html>",
+                                    "<html><body><p>hello\t\tworld</p></body></html>",
+                                    'keep_inner_whitespaces' => true }
+
+  it { expect_comparable_html_to_eq "<html><body><p>      hello\t\tworld     </p></body></html>",
+                                    "<html><body><p> hello world </p></body></html>",
+                                    'keep_outer_whitespaces' => true }
+
+  it { expect_comparable_html_to_eq "<html><body><p>      hello\t\tworld     </p></body></html>",
+                                    "<html><body><p>      hello\t\tworld     </p></body></html>",
+                                    'keep_inner_whitespaces' => true,
+                                    'keep_outer_whitespaces' => true }
+
   it { expect_comparable_html_to_eq "<html><body><p>\n\n      hello\n     world     </p></body></html>", '<html><body><p>hello world</p></body></html>' }
   it { expect_comparable_html_to_eq " <html>  \n<body>  <p>hello</p></body></html>", '<html><body><p>hello</p></body></html>' }
 end

--- a/spec/test_dom_hook_spec.rb
+++ b/spec/test_dom_hook_spec.rb
@@ -1,0 +1,16 @@
+require_relative 'spec_helper'
+
+describe HtmlTestDomHook do
+  subject { HtmlTestDomHook.new }
+
+  def expect_comparable_html_to_eq(original, expected)
+    expect(subject.send(:comparable_hexp, original, {}).to_html).to eq expected
+  end
+
+  it { expect_comparable_html_to_eq '<div> </div>', '<html><body><div></div></body></html>' }
+  it { expect_comparable_html_to_eq '<html></html>', '<html></html>' }
+  it { expect_comparable_html_to_eq "<html><body><p> hello world </p></body></html>", '<html><body><p>hello world</p></body></html>' }
+  it { expect_comparable_html_to_eq "<html><body><p>      hello     world     </p></body></html>", '<html><body><p>hello world</p></body></html>' }
+  it { expect_comparable_html_to_eq "<html><body><p>\n\n      hello\n     world     </p></body></html>", '<html><body><p>hello world</p></body></html>' }
+  it { expect_comparable_html_to_eq " <html>  \n<body>  <p>hello</p></body></html>", '<html><body><p>hello</p></body></html>' }
+end


### PR DESCRIPTION
Fixes #34 