### PR TITLE
Normalize rgb comparison

### DIFF
--- a/lib/checker/css.rb
+++ b/lib/checker/css.rb
@@ -19,7 +19,15 @@ end
 class String
   # Avoids properties like rgb(5, 10, 15) to be split
   def css_values
-    scan /[^\s]+\(\s*\g<0>\s*(?:,\s*\g<0>)*\)|[^\s]+/
+    scan(/[^\s]+\(\s*\g<0>\s*(?:,\s*\g<0>)*\)|[^\s]+/).map(&:normalize_rgb_css_value)
+  end
+
+  def normalize_rgb_css_value
+    if starts_with?("rgb(")
+      gsub(" ", "")
+    else
+      self
+    end
   end
 
   def comma_separated_words
@@ -77,7 +85,7 @@ module Checker
       if inspection_value =~ COMMA_SEPARATED_INSPECTION_REGEX
         comma_separated_values_match? inspection_value, actual_value
       else
-        actual_value.css_values.include? inspection_value
+        actual_value.css_values.include? inspection_value.normalize_rgb_css_value
       end
     end
 

--- a/spec/expectations_spec.rb
+++ b/spec/expectations_spec.rb
@@ -106,6 +106,16 @@ describe HtmlExpectationsHook do
         { expectation: {binding: 'css:h2', inspection: 'DeclaresStyle:color:blue'}, result: true}] }
   end
 
+  describe 'case insensitive body DeclaresStyle: ' do
+    let(:code) { '<head> <style> p { color: rgb(5,5,5) } </style> </head>'}
+    let(:expectations) { [
+        {binding: 'css:p', inspection: 'DeclaresStyle:color:rgb(5, 5, 5)'}] }
+
+
+    it { expect(result).to eq [
+        { expectation: {binding: 'css:p', inspection: 'DeclaresStyle:color:rgb(5, 5, 5)'}, result: true}] }
+  end
+
   describe 'body DeclaresStyle: for screen 992' do
     let(:code) { '<head> <style> @media screen (max-width: 992px) {body {color: red}}</style> </head>'}
     let(:expectations) { [


### PR DESCRIPTION
:dart: Goal

Fixes https://github.com/mumuki/mumuki-html-runner/issues/59

:memo: Details

This is a very conservative fix, only for `rgb`. It does not try to generalize any function related behavior, since whitespaces in css my be a little tricky. 

 